### PR TITLE
Close the underlying iterator.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,18 @@
+sudo: false
 language: python
 python:
     - 2.7
     - 3.4
     - 3.5
+    - 3.6
+    - pypy-5.4.1
 install:
-    - pip install zc.buildout
-    - buildout
+    - pip install -U pip setuptools
+    - pip install -U -e .[test] zope.testrunner
 script:
-    - bin/test -v1j99
+    - zope-testrunner --test-path=src -v1j99
 notifications:
     email: false
+cache: pip
+before_cache:
+  - rm -f $HOME/.cache/pip/log/debug.log

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,8 +1,21 @@
-Changes
-=======
+=========
+ Changes
+=========
+
+1.2.0 (unreleased)
+==================
+
+- Add support for Python 3.6 and PyPy.
+
+- Restrict ZODB dependency to less than 5.0, and transaction to less
+  than 2.0. ServerZlibStorage currently doesn't work with ZEO 5.
+  (https://github.com/zopefoundation/zc.zlibstorage/issues/5).
+
+- Close the underlying iterator used by the ``iterator`` wrapper when
+  it is closed. (https://github.com/zopefoundation/zc.zlibstorage/issues/4)
 
 1.1.0 (2016-08-03)
-------------------
+==================
 
 - Fixed an incompatibility with ZODB5.  The previously optional and
   ignored version argument to the database ``invalidate`` method is now
@@ -11,16 +24,16 @@ Changes
 - Drop Python 2.6, 3.2, and 3.3 support. Added Python 3.4 and 3.5 support.
 
 1.0.0 (2015-11-11)
-------------------
+==================
 
 - Python 3 support contributed by Christian Tismer.
 
 0.1.1 (2010-05-26)
-------------------
+==================
 
 - Fixed a packaging bug.
 
 0.1.0 (2010-05-20)
-------------------
+==================
 
 Initial release

--- a/setup.py
+++ b/setup.py
@@ -13,8 +13,8 @@
 ##############################################################################
 name, version = 'zc.zlibstorage', '1.1.0'
 
-install_requires = ['setuptools', 'ZODB', 'zope.interface']
-extras_require = dict(test=['zope.testing', 'manuel', 'ZEO'])
+install_requires = ['setuptools', 'ZODB < 5', 'zope.interface', 'transaction < 2']
+extras_require = dict(test=['zope.testing', 'manuel', 'ZEO[test] < 5'])
 
 entry_points = """
 """
@@ -41,9 +41,13 @@ setup(
     long_description=long_description,
     description=long_description.split('\n')[1],
     classifiers=[
+        "Programming Language :: Python",
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
+        'Programming Language :: Python :: 3.6',
+        "Programming Language :: Python :: Implementation :: CPython",
+        "Programming Language :: Python :: Implementation :: PyPy",
     ],
     packages=[name.split('.')[0], name],
     namespace_packages=[name.split('.')[0]],

--- a/src/zc/zlibstorage/__init__.py
+++ b/src/zc/zlibstorage/__init__.py
@@ -95,8 +95,7 @@ class ZlibStorage(object):
             oid, serial, self._transform(data), version, prev_txn, transaction)
 
     def iterator(self, start=None, stop=None):
-        for t in self.base.iterator(start, stop):
-            yield Transaction(t)
+        return _Iterator(self.base.iterator(start, stop))
 
     def storeBlob(self, oid, oldserial, data, blobfilename, version,
                   transaction):
@@ -155,6 +154,35 @@ class ServerZlibStorage(ZlibStorage):
         'load', 'loadBefore', 'loadSerial', 'store', 'restore',
         'iterator', 'storeBlob', 'restoreBlob', 'record_iternext',
         )
+
+class _Iterator(object):
+    # A class that allows for proper closing of the underlying iterator
+    # as well as avoiding any GC issues.
+    # (https://github.com/zopefoundation/zc.zlibstorage/issues/4)
+
+    def __init__(self, base_it):
+        self._base_it = base_it
+
+    def __iter__(self):
+        return self
+
+    def __next__(self):
+        return Transaction(next(self._base_it))
+
+    next = __next__
+
+    def close(self):
+        try:
+            base_close = self._base_it.close
+        except AttributeError:
+            pass
+        else:
+            base_close()
+        finally:
+            self._base_it = iter(())
+
+    def __getattr__(self, name):
+        return getattr(self._base_it, name)
 
 class Transaction(object):
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,11 +1,10 @@
 [tox]
 envlist =
-    py26,py27,py32,py33
+    py27,py34,py35,py36,pypy
 
 [testenv]
 deps =
-    zope.testing
-    manuel
-    ZEO
+    .[test]
+    zope.testrunner
 commands =
-    python setup.py test -q
+    zope-testrunner --test-path=src -v1j99


### PR DESCRIPTION
Fixes #4.

Also add PyPy support.

Modernize the .travis.yml: sudo false, pip caching, same testrunner as
tox.ini.

Pin ZODB/ZEO to old versions because ServerZlibStorage is broken for
ZODB 5. Will address in a subsequent PR.