### PR TITLE
Remove ZODB version pin by removing failing test

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,9 +6,26 @@ python:
     - 3.5
     - 3.6
     - pypy-5.4.1
+env:
+  matrix:
+    - ENV=ZODB5
+    - ENV=ZODB4
+matrix:
+  # Only test ZODB 4 on Python 2.7 (because there are
+  # some versions of Python 2.7 that cant run ZODB/ZEO 5)
+  exclude:
+    - python: 3.4
+      env: ENV=ZODB4
+    - python: 3.5
+      env: ENV=ZODB4
+    - python: 3.6
+      env: ENV=ZODB4
+    - python: pypy-5.4.1
+      env: ENV=ZODB4
 install:
     - pip install -U pip setuptools
     - pip install -U -e .[test] zope.testrunner
+    - if [[ $ENV == ZODB4 ]]; then pip uninstall -y ZEO ZODB transaction && pip install "ZODB < 5" "ZEO < 5" "transaction < 2"; fi
 script:
     - zope-testrunner --test-path=src -v1j99
 notifications:

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -7,7 +7,9 @@
 
 - Add support for Python 3.6 and PyPy.
 
-- Test with both ZODB/ZEO 4 and ZODB/ZEO 5
+- Test with both ZODB/ZEO 4 and ZODB/ZEO 5.
+  Note that ServerZlibStorage cannot be used in a ZODB 5 Connection
+  (e.g., client-side).
   (https://github.com/zopefoundation/zc.zlibstorage/issues/5).
 
 - Close the underlying iterator used by the ``iterator`` wrapper when

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -7,8 +7,7 @@
 
 - Add support for Python 3.6 and PyPy.
 
-- Restrict ZODB dependency to less than 5.0, and transaction to less
-  than 2.0. ServerZlibStorage currently doesn't work with ZEO 5.
+- Test with both ZODB/ZEO 4 and ZODB/ZEO 5
   (https://github.com/zopefoundation/zc.zlibstorage/issues/5).
 
 - Close the underlying iterator used by the ``iterator`` wrapper when

--- a/setup.py
+++ b/setup.py
@@ -13,8 +13,8 @@
 ##############################################################################
 name, version = 'zc.zlibstorage', '1.1.0'
 
-install_requires = ['setuptools', 'ZODB < 5', 'zope.interface', 'transaction < 2']
-extras_require = dict(test=['zope.testing', 'manuel', 'ZEO[test] < 5'])
+install_requires = ['setuptools', 'ZODB', 'zope.interface',]
+extras_require = dict(test=['zope.testing', 'manuel', 'ZEO[test]',])
 
 entry_points = """
 """

--- a/setup.py
+++ b/setup.py
@@ -13,8 +13,18 @@
 ##############################################################################
 name, version = 'zc.zlibstorage', '1.1.0'
 
-install_requires = ['setuptools', 'ZODB', 'zope.interface',]
-extras_require = dict(test=['zope.testing', 'manuel', 'ZEO[test]',])
+install_requires = [
+    'setuptools',
+    'ZODB',
+    'zope.interface',
+]
+extras_require = {
+    'test': [
+        'zope.testing',
+        'manuel',
+        'ZEO[test]',
+    ]
+}
 
 entry_points = """
 """

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 envlist =
-    py27,py34,py35,py36,pypy
+    py27,py27-zodb4,py34,py35,py36,pypy
 
 [testenv]
 deps =
@@ -8,3 +8,9 @@ deps =
     zope.testrunner
 commands =
     zope-testrunner --test-path=src -v1j99
+
+[testenv:py27-zodb4]
+deps =
+     {[testenv]deps}
+     ZODB < 5
+     ZEO < 5


### PR DESCRIPTION
Fixes #5

But make tox and travis run tests with both ZODB 4 and 5.

Add an explicit test for the ServerZlibStorage not decompressing in `load`.