### PR TITLE
tests: Switch to zodbpickle

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -23,6 +23,7 @@ extras_require = {
         'zope.testing',
         'manuel',
         'ZEO[test]',
+        'zodbpickle',
     ]
 }
 

--- a/src/zc/zlibstorage/tests.py
+++ b/src/zc/zlibstorage/tests.py
@@ -18,7 +18,7 @@ import doctest
 import zlib
 import binascii
 import re
-import pickle
+from zodbpickle import pickle
 
 import manuel.capture
 import manuel.doctest


### PR DESCRIPTION
Else, when ran agains ZODB5 it crashes like below and almost no tests
are run:

    Running tests at level 1
    Running zope.testrunner.layer.UnitTests tests:
      Set up zope.testrunner.layer.UnitTests in 0.000 seconds.
      Running:
    ......

    Failure in test test_mixed_compressed_and_uncompressed_and_packing (zc.zlibstorage.tests)
    Failed doctest test for zc.zlibstorage.tests.test_mixed_compressed_and_uncompressed_and_packing
      File "/home/kirr/src/wendelin/z/zc.zlibstorage/src/zc/zlibstorage/tests.py", line 131, in test_mixed_compressed_and_uncompressed_and_packing

    ----------------------------------------------------------------------
    File "/home/kirr/src/wendelin/z/zc.zlibstorage/src/zc/zlibstorage/tests.py", line 167, in zc.zlibstorage.tests.test_mixed_compressed_and_uncompressed_and_packing
    Failed example:
        pickle.loads(zlib.decompress(data[2:]))
    Exception raised:
        Traceback (most recent call last):
          File "/usr/lib/python2.7/doctest.py", line 1315, in __run
            compileflags, 1) in test.globs
          File "<doctest zc.zlibstorage.tests.test_mixed_compressed_and_uncompressed_and_packing[19]>", line 1, in <module>
            pickle.loads(zlib.decompress(data[2:]))
          File "/usr/lib/python2.7/pickle.py", line 1388, in loads
            return Unpickler(file).load()
          File "/usr/lib/python2.7/pickle.py", line 864, in load
            dispatch[key](self)
          File "/usr/lib/python2.7/pickle.py", line 892, in load_proto
            raise ValueError, "unsupported pickle protocol: %d" % proto
        ValueError: unsupported pickle protocol: 3

After this patch testing is in much better shape but the tests still don't fully pass due to failure in
checkTransactionExtensionFromIterator (zc.zlibstorage.tests.FileStorageClientZlibZEOZlibTests):

    (neo) (z-dev) (g.env) kirr@deca:~/src/wendelin/z/zc.zlibstorage$ zope-testrunner --test-path=src -v
    Running tests at level 1
    Running zope.testrunner.layer.UnitTests tests:
      Set up zope.testrunner.layer.UnitTests in 0.000 seconds.
      Running:
    .......
      Ran 7 tests with 0 failures, 0 errors and 0 skipped in 0.029 seconds.
    Running .zlibstoragetests.FileStorageClientZlibZEOServerZlibTests tests:
      Tear down zope.testrunner.layer.UnitTests in 0.000 seconds.
      Set up .zlibstoragetests.FileStorageClientZlibZEOServerZlibTests in 0.000 seconds.
      Running:
    ................................................................................

    Failure in test checkTransactionExtensionFromIterator (zc.zlibstorage.tests.FileStorageClientZlibZEOServerZlibTests)
    Traceback (most recent call last):
      File "/usr/lib/python2.7/unittest/case.py", line 329, in run
        testMethod()
      File "/home/kirr/src/wendelin/z/ZODB/src/ZODB/tests/IteratorStorage.py", line 115, in checkTransactionExtensionFromIterator
        self.assertNotEqual(extension_bytes, txn.extension_bytes)
      File "/usr/lib/python2.7/unittest/case.py", line 522, in assertNotEqual
        raise self.failureException(msg)
    AssertionError: '\x80\x03}q\x01U\x03fooK\x01s.' == '\x80\x03}q\x01U\x03fooK\x01s.'

    .........................
      Ran 105 tests with 1 failures, 0 errors and 0 skipped in 18.029 seconds.
    Running .zlibstoragetests.FileStorageClientZlibZEOZlibTests tests:
      Tear down .zlibstoragetests.FileStorageClientZlibZEOServerZlibTests in 0.000 seconds.
      Set up .zlibstoragetests.FileStorageClientZlibZEOZlibTests in 0.000 seconds.
      Running:
    ................................................................................

    Failure in test checkTransactionExtensionFromIterator (zc.zlibstorage.tests.FileStorageClientZlibZEOZlibTests)
    Traceback (most recent call last):
      File "/usr/lib/python2.7/unittest/case.py", line 329, in run
        testMethod()
      File "/home/kirr/src/wendelin/z/ZODB/src/ZODB/tests/IteratorStorage.py", line 115, in checkTransactionExtensionFromIterator
        self.assertNotEqual(extension_bytes, txn.extension_bytes)
      File "/usr/lib/python2.7/unittest/case.py", line 522, in assertNotEqual
        raise self.failureException(msg)
    AssertionError: '\x80\x03}q\x01U\x03fooK\x01s.' == '\x80\x03}q\x01U\x03fooK\x01s.'

    .........................
      Ran 105 tests with 1 failures, 0 errors and 0 skipped in 17.240 seconds.
    Running .zlibstoragetests.FileStorageZEOZlibTests tests:
      Tear down .zlibstoragetests.FileStorageClientZlibZEOZlibTests in 0.000 seconds.
      Set up .zlibstoragetests.FileStorageZEOZlibTests in 0.000 seconds.
      Running:
    .........................................................................................................
      Ran 105 tests with 0 failures, 0 errors and 0 skipped in 17.808 seconds.
    Running .zlibstoragetests.FileStorageZlibRecoveryTest tests:
      Tear down .zlibstoragetests.FileStorageZEOZlibTests in 0.000 seconds.
      Set up .zlibstoragetests.FileStorageZlibRecoveryTest in 0.000 seconds.
      Running:
    ....
      Ran 4 tests with 0 failures, 0 errors and 0 skipped in 0.013 seconds.
    Running .zlibstoragetests.FileStorageZlibTests tests:
      Tear down .zlibstoragetests.FileStorageZlibRecoveryTest in 0.000 seconds.
      Set up .zlibstoragetests.FileStorageZlibTests in 0.000 seconds.
      Running:
    ......................................................................................................
      Ran 102 tests with 0 failures, 0 errors and 1 skipped in 6.505 seconds.
    Running .zlibstoragetests.FileStorageZlibTestsWithBlobsEnabled tests:
      Tear down .zlibstoragetests.FileStorageZlibTests in 0.000 seconds.
      Set up .zlibstoragetests.FileStorageZlibTestsWithBlobsEnabled in 0.000 seconds.
      Running:
    ......................................................................................................
      Ran 102 tests with 0 failures, 0 errors and 1 skipped in 6.660 seconds.
    Running zc.zlibstorage.tests.ZLibHackLayer tests:
      Tear down .zlibstoragetests.FileStorageZlibTestsWithBlobsEnabled in 0.000 seconds.
      Set up zc.zlibstorage.tests.ZLibHackLayer in 0.000 seconds.
      Running:
    ......................................................................................................
      Ran 102 tests with 0 failures, 0 errors and 1 skipped in 6.754 seconds.
    Tearing down left over layers:
      Tear down zc.zlibstorage.tests.ZLibHackLayer in 0.000 seconds.

    Tests with failures:
       checkTransactionExtensionFromIterator (zc.zlibstorage.tests.FileStorageClientZlibZEOServerZlibTests)
       checkTransactionExtensionFromIterator (zc.zlibstorage.tests.FileStorageClientZlibZEOZlibTests)
    Total: 632 tests, 2 failures, 0 errors and 3 skipped in 1 minutes 13.340 seconds.