### PR TITLE
tests: Fix them for ZODB >= 5.6.0

### DIFF
--- a/src/zc/zlibstorage/tests.py
+++ b/src/zc/zlibstorage/tests.py
@@ -363,6 +363,8 @@ class FileStorageZEOZlibTests(ZEO.tests.testZEO.FileStorageTests):
 
 class FileStorageClientZlibZEOZlibTests(FileStorageZEOZlibTests):
 
+    use_extension_bytes = True
+
     def _wrap_client(self, client):
         return zc.zlibstorage.ZlibStorage(client)
 


### PR DESCRIPTION
If test class does not indicate that underlying storage supports
extension_bytes (see https://github.com/zopefoundation/ZODB/pull/207),
then ZODB.tests.IteratorStorage will verify that extension_bytes is
computed from extension instead of taken from on-storage raw value:

https://github.com/zopefoundation/ZODB/blob/5.6.0-48-gbc13ca74b/src/ZODB/tests/IteratorStorage.py#L93-L115

However when underlying storage supports extension_bytes, so is
zlibstorage that wraps it.

Many classes in zc.zlibstorage tests inherit from classes test classes
for FileStorage

https://github.com/zopefoundation/zc.zlibstorage/blob/1.2.0-4-g51cca6b/src/zc/zlibstorage/tests.py#L314-L338

Those classes will have .use_extension_bytes properly set because ZODB
sets so for FileStorageTests:

https://github.com/zopefoundation/ZODB/blob/5.6.0-48-gbc13ca74b/src/ZODB/tests/testFileStorage.py#L44-L62

However for tests that inherit from ZEO tests, .use_extension_bytes is
not uniformly set for ZEO over FileStorage, and so with ZODB >= 5.6.0
zc.zlibstorage fails with

    Failure in test checkTransactionExtensionFromIterator (zc.zlibstorage.tests.FileStorageClientZlibZEOServerZlibTests)
    Traceback (most recent call last):
      File "/usr/lib/python2.7/unittest/case.py", line 329, in run
        testMethod()
      File "/home/kirr/src/wendelin/z/ZODB/src/ZODB/tests/IteratorStorage.py", line 115, in checkTransactionExtensionFromIterator
        self.assertNotEqual(extension_bytes, txn.extension_bytes)
      File "/usr/lib/python2.7/unittest/case.py", line 522, in assertNotEqual
        raise self.failureException(msg)
    AssertionError: '\x80\x03}q\x01U\x03fooK\x01s.' == '\x80\x03}q\x01U\x03fooK\x01s.'

and

    Failure in test checkTransactionExtensionFromIterator (zc.zlibstorage.tests.FileStorageClientZlibZEOZlibTests)
    Traceback (most recent call last):
      File "/usr/lib/python2.7/unittest/case.py", line 329, in run
        testMethod()
      File "/home/kirr/src/wendelin/z/ZODB/src/ZODB/tests/IteratorStorage.py", line 115, in checkTransactionExtensionFromIterator
        self.assertNotEqual(extension_bytes, txn.extension_bytes)
      File "/usr/lib/python2.7/unittest/case.py", line 522, in assertNotEqual
        raise self.failureException(msg)
    AssertionError: '\x80\x03}q\x01U\x03fooK\x01s.' == '\x80\x03}q\x01U\x03fooK\x01s.'

Fix it similarly to https://github.com/zopefoundation/ZEO/commit/db24ed2f